### PR TITLE
Bump version of `nil_ls` language server

### DIFF
--- a/packages/nil/package.yaml
+++ b/packages/nil/package.yaml
@@ -12,7 +12,7 @@ categories:
 
 source:
   # renovate:versioning=loose
-  id: pkg:cargo/nil@2022-12-01?repository_url=https://github.com/oxalica/nil
+  id: pkg:cargo/nil@2023-08-09?repository_url=https://github.com/oxalica/nil
 
 bin:
   nil: cargo:nil


### PR DESCRIPTION
the Nil language for server is incompatible with newer versions of Nix. When building the version from Mason it fails. The fix incorperated in this newer version should be backwards compatible. See https://github.com/oxalica/nil/issues/93 for more context.

I've also bumped it to the latest version. There are more tags possible, I just picked the latest. The tags are listed here: https://github.com/oxalica/nil/tags